### PR TITLE
Remove invalid reference to a CommandLineRunner @Bean

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,8 +66,6 @@ include::initial/src/main/java/hello/Application.java[]
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/spring-boot-application.adoc[]
 
-There is also a `CommandLineRunner` method marked as a `@Bean` and this runs on start up. It retrieves all the beans that were created either by your app or were automatically added thanks to Spring Boot. It sorts them and prints them out.
-
 == Run the application
 To run the application, execute:
 


### PR DESCRIPTION
This seems to be a leftover from previous versions.