### PR TITLE
Update for spring boot's starters Github link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -246,7 +246,7 @@ Because we didn't enable it, the request is blocked by the virtue of not existin
 For more details about each of these REST points and how you can tune their settings with an `application.properties` file, you can read detailed http://docs.spring.io/spring-boot/docs/{spring_boot_version}/reference/htmlsingle/#production-ready-endpoints[docs about the endpoints].
 
 == View Spring Boot's starters
-You have seen some of http://docs.spring.io/spring-boot/docs/{spring_boot_version}/reference/htmlsingle/#using-boot-starter[Spring Boot's "starters"]. You can see them all https://github.com/spring-projects/spring-boot/tree/master/spring-boot-starters[here in source code].
+You have seen some of http://docs.spring.io/spring-boot/docs/{spring_boot_version}/reference/htmlsingle/#using-boot-starter[Spring Boot's "starters"]. You can see them all https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters[here in source code].
 
 == JAR support and Groovy support
 The last example showed how Spring Boot makes it easy to wire beans you may not be aware that you need. And it showed how to turn on convenient management services.


### PR DESCRIPTION
The link to see the spring boot starters source code in GitHub leads to the wrong page showing the 404 page. I updated the link to  go to the actual page that shows the code for spring boot starts