### PR TITLE
Remove java.version property

### DIFF
--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -20,11 +20,6 @@
         </dependency>
     </dependencies>
 
-    <properties>
-        <java.version>1.8</java.version>
-    </properties>
-
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
setting java.version property to 1.8 is no longer required, as it is already included in the spring-boot-starter-parent pom.xml as of 2.0.0 release.