### PR TITLE
Remove java.version property

### DIFF
--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -33,10 +33,6 @@
         <!-- end::tests[] -->
     </dependencies>
 
-    <properties>
-        <java.version>1.8</java.version>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -19,12 +19,7 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
     </dependencies>
-
-    <properties>
-        <java.version>1.8</java.version>
-    </properties>
-
-
+    
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Obvious Fix

setting java.version property to 1.8 is no longer required, as it is already included in the spring-boot-starter-parent pom.xml as of 2.0.0 release.