### PR TITLE
Fix typo for endpoint configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -213,7 +213,7 @@ You will see a new set of RESTful end points added to the application. These are
 They include: errors, http://localhost:8080/actuator/health[actuator/health], http://localhost:8080/actuator/info[actuator/info], http://localhost:8080/actuator[actuator].
 
 NOTE: There is also a `/actuator/shutdown` endpoint, but it's only visible by default via JMX. To http://docs.spring.io/spring-boot/docs/{spring_boot_version}/reference/htmlsingle/#production-ready-endpoints-enabling-endpoints[enable it as an HTTP endpoint], add
-`management.endpoints.shutdown.enabled=true` to your `application.properties` file.
+`management.endpoints.web.exposure.include=*` and `management.endpoint.shutdown.enabled=true` to your `application.properties` file.
 
 It's easy to check the health of the app.
 


### PR DESCRIPTION
While working through the guide I discovered a small typo that took me some time to figure out.

I'm just learning things, but I guess this is due to version 2.0?

Maybe this could prevent others from having the same headache as I had, figuring it out. :)
