### PR TITLE
Fix Gradlew version to support Java 11

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+ports:
+  - port: 8080
+    onOpen: open-preview
+tasks:
+  - before: cd complete
+    init: ./gradlew clean build
+    command: ./gradlew bootRun
+github:
+  prebuilds:
+      pullRequestsFromForks: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,9 @@ ports:
 tasks:
   - before: cd complete
     init: ./gradlew clean build
-    command: ./gradlew bootRun
+    command: >
+      code complete/src/main/java/hello/HelloController.java &&
+      ./gradlew bootRun
 github:
   prebuilds:
       pullRequestsFromForks: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,11 +2,10 @@ ports:
   - port: 8080
     onOpen: open-preview
 tasks:
+  - command: code complete/src/main/java/hello/HelloController.java
   - before: cd complete
     init: ./gradlew clean build
-    command: >
-      code complete/src/main/java/hello/HelloController.java &&
-      ./gradlew bootRun
+    command: ./gradlew bootRun
 github:
   prebuilds:
       pullRequestsFromForks: true

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,9 @@
 :icons: font
 :source-highlighter: prettify
 :project_id: gs-spring-boot
+
+image::https://gitpod.io/button/open-in-gitpod.svg[Open in Gitpod,link=https://gitpod.io/#https://github.com/gitpod-io/gs-spring-boot]
+
 This guide provides a sampling of how {spring-boot}[Spring Boot] helps you accelerate and facilitate application development. As you read more Spring Getting Started guides, you will see more use cases for Spring Boot.
 It is meant to give you a quick taste of Spring Boot. If you want to create your own Spring Boot-based project, visit
 http://start.spring.io/[Spring Initializr], fill in your project details, pick your options, and you can download either

--- a/complete/gradle/wrapper/gradle-wrapper.properties
+++ b/complete/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip


### PR DESCRIPTION
Fixes:
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine java version from '11.0.5'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```