### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+  - init: echo "Replace me with a build script for the project."
+    command: echo "Replace me with omething that should run on every start, or just
+      remove me entirely."

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,5 @@
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/spring-guides/gs-spring-boot) 
+
 :spring_boot_version: 2.2.2.RELEASE
 :spring-boot: https://github.com/spring-projects/spring-boot
 :toc:


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.