### PR TITLE
Upgrade from gradle 7.0 to 7.2

### DIFF
--- a/initial/gradle/wrapper/gradle-wrapper.properties
+++ b/initial/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The latest version of JDK is 17. Gradle is 7.2. 

Upgrading to 7.2 will avoid the "unsupported class file major version" error when you `./gradlew bootRun`. This occurs because Gradle 7.0 does not know about JDK 17.